### PR TITLE
Wip 6.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ edition = "2018"
 [dependencies]
 log = "0.4.14"
 log4rs = { version = "1.0", features = ["default", "gzip"] }
-clap = "=3.0.0-beta.4"
-clap_derive = "=3.0.0-beta.4"
+clap = { version = "3.0.14", features = ["derive"] }
 git-version = "0.3.5"
 tonic = "0.5.2"
 prost = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ prost = "0.8.0"
 tokio = { version = "1.0", features = ["full"] }
 hex = "0.4"
 
-cloud-util = "0.1"
-cita_cloud_proto = "=6.3.0"
-status_code = { package = "cloud-code", version = "0.1" }
+cloud-util = { git = "https://github.com/cita-cloud/cloud-util.git" }
+cita_cloud_proto = { git = "https://github.com/cita-cloud/cita_cloud_proto.git" }
+status_code = { package = "cloud-code", git = "https://github.com/cita-cloud/status_code.git" }
 
 r2d2 = "0.8.9"
 r2d2_sqlite = "0.18.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod config;
 mod crypto;
 mod kms;
 
-use clap::Clap;
+use clap::Parser;
 use git_version::git_version;
 use log::{debug, info, warn};
 
@@ -28,14 +28,14 @@ const GIT_HOMEPAGE: &str = "https://github.com/cita-cloud/kms_sm";
 
 /// This doc string acts as a help message when the user runs '--help'
 /// as do all doc strings on fields
-#[derive(Clap)]
+#[derive(Parser)]
 #[clap(version = "0.1.0", author = "Rivtower Technologies.")]
 struct Opts {
     #[clap(subcommand)]
     subcmd: SubCommand,
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 enum SubCommand {
     /// print information from git
     #[clap(name = "git")]
@@ -49,7 +49,7 @@ enum SubCommand {
 }
 
 /// A subcommand for run
-#[derive(Clap)]
+#[derive(Parser)]
 struct RunOpts {
     /// Sets grpc port of this service.
     #[clap(short = 'p', long = "port", default_value = "50005")]
@@ -66,7 +66,7 @@ struct RunOpts {
 }
 
 /// A subcommand for create
-#[derive(Clap)]
+#[derive(Parser)]
 struct CreateOpts {
     /// Sets path of db file.
     #[clap(short = 'd', long = "db")]


### PR DESCRIPTION
1 update clap
2 替换部分依赖从 crate -> github
对于 master 扮演开发分支的特点，我们自己的库由于经常需要更新使用 crate 的方式非常不利于开发，因此将这些库转为 github
！这个分支并不是 kms_sm 的 6.3.2 分支！